### PR TITLE
add PLT support for GA4 format, add consent signals plugin indetifier

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,11 @@
 homepage: "https://www.awin.com"
 versions:
   # Latest version 
+  - sha: e7651ea3b74c6aefbcef53497ee710e8757e2c57
+    changeNotes: Added support for GA4 dataLayer keys in PLT. Added support for splitting PLT commission groups according to parts price. Added support for Consent Signals Plugin indentifier.
+  # Older versions
   - sha: bb41feaa441206bfcb866430049501712d7e677a
     changeNotes: Added support for Awin Consent Signals.
-  # Older versions
   - sha: 537c0959ced9e8cb6527e1c3b42373716341ea0f
     changeNotes: Added Override Default Product Properties to allow advertisers to overwritte product properties for Product Level Tracking.
   - sha: 4dc467dc663df1c0b61845121853f4a09a8083b6

--- a/template.js
+++ b/template.js
@@ -7,7 +7,7 @@ const appendPixel = require('sendPixel');
 const encodeUriComponent = require('encodeUriComponent');
 const getType = require('getType');
 const getUrl = require('getUrl');
-const version = '1.0.6';
+const version = '1.0.7';
 const copyFromWindow = require('copyFromWindow'); 
 const existingAwinObject = copyFromWindow('AWIN'); 
 
@@ -33,6 +33,9 @@ AWIN.Tracking.Sale.customerAcquisition = enc(data.customerAcquisition);
 AWIN.Tracking.Sale.test = enc(data.test);
 AWIN.Tracking.Sale.custom = [];
 AWIN.Tracking.Sale.custom[0] = "gtmPlugin_" + version;
+if (AWIN.Tracking.gtmConsentSignals) {
+  AWIN.Tracking.Sale.custom[0] += AWIN.Tracking.gtmConsentSignals;
+}
 if (data.custom && getType(data.custom) == "array") {
   var index = 1;
   for (var i = 0; i < data.custom.length; i++) {
@@ -62,11 +65,12 @@ window('zx_products', zx_products, true);
 
 var buildNs = function() {
     //build the URL: 
-    var url = "https://www.awin1.com/sread.img?tt=ns&tv=2&merchant=" + enc(data.advertiserId) + "&amount=" + AWIN.Tracking.Sale.amount + "&cr=" + AWIN.Tracking.Sale.currency + "&ref=" + AWIN.Tracking.Sale.orderRef  + "&parts=" + AWIN.Tracking.Sale.parts + "&vc=" + AWIN.Tracking.Sale.voucher + "&customeracquisition=" + AWIN.Tracking.Sale.customerAcquisition + "&t=" + AWIN.Tracking.Sale.test + "&ch=" + AWIN.Tracking.Sale.channel + "&p1=gtmPlugin_" + version;
+    var url = "https://www.awin1.com/sread.img?tt=ns&tv=2&merchant=" + enc(data.advertiserId) + "&amount=" + AWIN.Tracking.Sale.amount + "&cr=" + AWIN.Tracking.Sale.currency + "&ref=" + AWIN.Tracking.Sale.orderRef  + "&parts=" + AWIN.Tracking.Sale.parts + "&vc=" + AWIN.Tracking.Sale.voucher + "&customeracquisition=" + AWIN.Tracking.Sale.customerAcquisition + "&t=" + AWIN.Tracking.Sale.test + "&ch=" + AWIN.Tracking.Sale.channel + "&" + AWIN.Tracking.Sale.custom[0];
   
     if (AWIN.Tracking.AdvertiserConsent !== undefined) {
       url += "&cons=" + (AWIN.Tracking.AdvertiserConsent ? "1" : "0");
     }
+  
     return url;
 };
 
@@ -74,6 +78,18 @@ const nsUrl = buildNs();
 appendPixel(nsUrl);
 
 //PLT
+//unpack multiple cgs into a json
+if (data.cg.indexOf('|') > 0) {
+  var individualParts = data.cg.split("|");
+  var invertedPartsObject = individualParts.reduce(function(obj, item) {
+    var parts = item.split(":");
+    //invert the key-value pair so that we can access the cg code using the price as key
+    var key = parts[1];
+    var value = parts[0];
+    obj[key] = value;
+    return obj;
+  }, {});
+}
 
 let productId = data.productId;
 let productName = data.productName;
@@ -83,18 +99,23 @@ let productSku = data.productSku;
 let productCg = data.productCg;
 let productCategory = data.productCategory;
 
-
 if (typeof data.plt == "object") {
   for (var i = 0; i < data.plt.length;i++) {
   var plt = "";
+  var price = (data.plt[i][productPrice] || data.plt[i].price);
+  //set the cg according to price  
+  if (invertedPartsObject){
+    var cgPerProduct = invertedPartsObject[price];
+  }
+   
   plt += "AW:P|" + data.advertiserId + "|"+ AWIN.Tracking.Sale.orderRef + "|" +
-  (data.plt[i][productId] || data.plt[i].id) + "|" +
-  (data.plt[i][productName] || data.plt[i].name) + "|" +
-  (data.plt[i][productPrice] || data.plt[i].price) + "|" +
+  (data.plt[i][productId] || data.plt[i].id || data.plt[i].item_id) + "|" +
+  (data.plt[i][productName] || data.plt[i].name || data.plt[i].item_name) + "|" +
+   price + "|" +
   (data.plt[i][productQuantity] || data.plt[i].quantity) + "|" +
-  (data.plt[i][productSku] || data.plt[i].sku) + "|" +
-  (data.plt[i][productCg] || data.plt[i].cGroup || productCg) + "|" +
-  (data.plt[i][productCategory] || data.plt[i].category);
+  (data.plt[i][productSku] || data.plt[i].sku || data.plt[i].item_id) + "|" +
+  (data.plt[i][productCg] || data.plt[i].cGroup || productCg || cgPerProduct || "DEFAULT") + "|" +
+  (data.plt[i][productCategory] || data.plt[i].category || data.plt[i].item_category);
   appendPixel("https://www.awin1.com/basket.php?product_line=" + encodeUriComponent(plt));
   }
 }


### PR DESCRIPTION
Changes: 
-use the identifier set by Awin Consent Signals
-use GA4 dataLayer keys for PLT data
-in PLT split CGs per product, based on amount
-update plugin version